### PR TITLE
ci: update chktex pre-submit

### DIFF
--- a/.github/workflows/pre-submit.units.yml
+++ b/.github/workflows/pre-submit.units.yml
@@ -83,15 +83,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
-      checks: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: j2kun/chktex-action@a3f031bbc2e5899f2b3efddcf9fc9ed25d525b98 # v2.1.0
-        with:
-          lint-all: true # Default: `false`
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y chktex
+      - run: make chktex
 
   actionlint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Description:**

Update `chktex` presubmit to not use `chktex-action`

**Related Issues:**

Fixes #48

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
