### PR TITLE
fix: build pre-submit job

### DIFF
--- a/.github/workflows/pre-submit.units.yml
+++ b/.github/workflows/pre-submit.units.yml
@@ -43,7 +43,9 @@ jobs:
             texlive-latex-extra \
             texlive-luatex \
             texlive-lang-japanese
+
       - run: make Ian_M_Lewis_Resume.pdf Ian_M_Lewis_Resume.ja.pdf
+
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         id: upload
         with:
@@ -52,7 +54,9 @@ jobs:
           path: |
             Ian_M_Lewis_Resume.pdf
             Ian_M_Lewis_Resume.ja.pdf
+
       - name: Write comment to PR
+        if: github.event_name == 'pull_request'
         env:
           ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
           PULL_REQUEST_NUM: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
**Description:**

Fix the `build` pre-submit job so that it doesn't try to create a PR comment when not a pull-request.

**Related Issues:**

n/a

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
