### PR TITLE
fix: update Kubernetes Meetup section: Japanese typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [CalVer](https://calver.org/).
 
+## [Unreleased]
+
+- Fix typo in Kubernetes Meetup section of Japanese translation
+  ([#106](https://github.com/ianlewis/resume/pull/106))
+
 ## [2025.07.01]
 
 - Added a publications section ([#81](https://github.com/ianlewis/resume/pull/81))

--- a/Ian_M_Lewis_Resume.ja.tex
+++ b/Ian_M_Lewis_Resume.ja.tex
@@ -402,7 +402,7 @@
     % responsible for event planning, recruiting speakers, and serve as MC for
     % most events. I recruited and mentored a self-sustaining group of lead
     % organizers and fully handed it off in 2020.
-    \budoux{2016年にKubernetes Meetup Tokyoを設立し、オーガナイザーとして7,700人以上の規模にまで成長させました。後任となるオーガナイザーチームを育成・指導し、2020年に運営を完全に引き継ぎました。}\footnote{https://k8sjp.connpass.com/}
+    \budoux{2016年にKubernetes Meetup Tokyoを設立し、オーガナイザーとして7,700人以上の規模にまで成長させました。後任となるオーガナイザーチームを育成・指導し、2020年に運営を完全に引き渡しました。}\footnote{https://k8sjp.connpass.com/}
 
     \item \textbf{\large PyCon JP} (2011年--2019年)
 


### PR DESCRIPTION
**Description:**

Fix Japanese typo in the Kubernetes Meetup section.

**Related Issues:**

Fixes #106

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
