### PR TITLE
feat: add creation date to resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [CalVer](https://calver.org/).
 
+## Unreleased
+
+- Added creation date to the resume header
+  ([#112](https://github.com/ianlewis/resume/issues/112))
+
 ## [2025.08.01]
 
 - Fix typo in Kubernetes Meetup section of Japanese translation

--- a/Ian_M_Lewis_Resume.ja.tex
+++ b/Ian_M_Lewis_Resume.ja.tex
@@ -47,7 +47,8 @@
     \parbox[t]{.5\textwidth}{
         \begin{flushright}
             ian@ianlewis.org\\
-            http://www.ianlewis.org/
+            http://www.ianlewis.org/\\
+            \the\year{}年\the\month{}月\the\day{}日\\
         \end{flushright}
     }
     \par

--- a/Ian_M_Lewis_Resume.tex
+++ b/Ian_M_Lewis_Resume.tex
@@ -41,7 +41,8 @@
     \parbox[t]{.5\textwidth}{
         \begin{flushright}
             ian@ianlewis.org\\
-            http://www.ianlewis.org/
+            http://www.ianlewis.org/\\
+            \today\\
         \end{flushright}
     }
     \par


### PR DESCRIPTION
**Description:**

Add creation date to the resume header.

**Related Issues:**

Fixes #112 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
